### PR TITLE
RAH: Remove leading bullet in Privilege Config

### DIFF
--- a/_8259-Catalog/configuration.md
+++ b/_8259-Catalog/configuration.md
@@ -12,7 +12,7 @@ The capability to configure the IOT device to meet the baseline configurations s
 
 ## Privilege Configuration
 
-- Ability to apply least privilege settings within the IOT device, ensuring that the processes operate at privilege levels no higher than necessary to accomplish required functions., including the ability to create within the IOT device additional processes, roles, and accounts as necessary, to achieve least privilege. Additional configurations that may be necessary:
+Ability to apply least privilege settings within the IOT device, ensuring that the processes operate at privilege levels no higher than necessary to accomplish required functions., including the ability to create within the IOT device additional processes, roles, and accounts as necessary, to achieve least privilege. Additional configurations that may be necessary:
   - Ability to establish least privilege IOT device settings to establish time/date/etc. when privileged roles, accounts, etc. should expire. 
   - Ability for the IOT device user to use IOT device settings to establish access privileges through IOT device interfaces or within the IOT device.
   - Ability to establish a defined list within the IOT device to control logical access privileges (e.g., admin, emergency, temporary, etc.).


### PR DESCRIPTION
Remove bullet from the descriptor sentence for the Privilege Configuration capabilities list.