### PR TITLE
Edit this section to address Issue #41 + more

### DIFF
--- a/_8259-Catalog/configuration.md
+++ b/_8259-Catalog/configuration.md
@@ -82,7 +82,7 @@ Ability to configure and change the IoT device's settings and software configura
   - Ability for the IOT device to detect unauthorized hardware and software components
   - Ability for the IOT device to take action when unauthorized components are detected as defined by the user.
 
-**Adaptable Configuration**
+## Adaptable Configuration
 Ability to establish adaptable configurations on the IOT device. Configurations that may be necessary: 
   - Ability to support different modes of IOT device operation with more restrictive access.
       -- "travel mode" for transit.


### PR DESCRIPTION
Doing this for an option to get the team's feedback on to see if this would streamline the editing efforts, or if it would complicate editing.

Instead of creating one issue and pull request for each edit/change, since we are at a point in our editing where we are in the final phases of editing the technical capabilities (if we are?), I wanted to edit the full configuration.md section to discuss during our meeting.  However, I do recognize that if there are one or more edits still needed, this would result in not accepting the full set of edits, so it would not be technically possible to create a very specific, isolated edit. Also, if multiple people are editing the same section, this could also complicate things. 

Changes made in this section: 

Reworded throughout this capabilities section for consistency throughout the sub-capabilities. 

Removed leading bullets for descriptor sentence at the beginning of each capability and sub-capability section.

I split some of the capabilities into two or more statements where they described two or more uniquely different capabilities. I'm thinking we should only list one capability per line. This will contribute to having each of the capabilities stand on its own, and support better understanding by the engineers using them.

I put some items in parentheses that provide more clarity, but don't impact the description/meaning of the capability.

I removed some information that provided reasons for the capability, but not a description of the capability.

This address Issue #41.