### PR TITLE
Typo and neutral language about identifiers

### DIFF
--- a/_Nontechnical/identity.md
+++ b/_Nontechnical/identity.md
@@ -26,4 +26,4 @@ Policies and procedures provide the details necessary to implement management an
 **Agency:**
 
 - Organizational IoT device policies and procedures establish the unique identification required for each IoT device associated with the system and critical system components within which it is used.
-
+- Organizational use of automated tools (sourced from the IoT device manufacturer or a third party vendor) to identify and maintain an inventory of devices using the unique device identification.

--- a/_Technical/identity.md
+++ b/_Technical/identity.md
@@ -18,7 +18,7 @@ Ability for device identification. Elements that may be necessary:
 - Ability to uniquely identify the IoT device physically.
 - Ability to uniquely identify the IoT device logically.
 - Ability to uniquely identify a remote IoT device.
-- Ability for the IoT device to support a unique device ID (e.g., to allow it to be linked to the person or process assigned to use the IoT device).
+- Ability for the IoT device to support a unique identifier (e.g., to allow it to be linked to the person or process assigned to use the IoT device).
 
 ## Actions Based on Device Identity
 
@@ -27,7 +27,7 @@ Actions that can occur based on or using the identity of the device. Elements th
 - Ability to configure IoT device access control policies using IoT device identity.
   - Ability to hide IoT device identity from non-authorized entities.
   - Ability for the IoT device to differentiate between authorized and unauthorized remote users.
-  - Ability for the IoT device to differentiate between authorized and authorized physical device users.
+  - Ability for the IoT device to differentiate between authorized and unauthorized physical device users.
 - Ability to monitor specific actions based on IoT device identity.
 - Ability to identify software loaded on the IoT device based on IoT device identity.
 


### PR DESCRIPTION
Fix Typo authorized/unauthorized

Suggest that the ID that is linked to the person or process may not be the device ID, but an ID assigned by a device management system. Proposing neutral language for that identifier. (See SP 800-53 IA-4)