### PR TITLE
remove minimum from documentation requirement

### DIFF
--- a/_Nontechnical/configuration.md
+++ b/_Nontechnical/configuration.md
@@ -19,7 +19,7 @@ Policies and procedures detail the necessary management and operational controls
 
 **Manufacturer:**
 
-- Provide documentation detailing the minimum configuration settings available within the IoT device, and how to change those settings, to meet their customers' needs and requirements.
+- Provide documentation detailing the configuration settings available within the IoT device, and how to change those settings, to meet their customers' needs and requirements.
 - Provide a process by which customers can contact the manufacturer to ask questions or obtain help related to the minimum requirements for the IoT device configuration settings.
 
 **Agency:**


### PR DESCRIPTION
While the policy is about the minimum configuration, the documentation from the manufacturer would be about the configuration options in general – removing the word minimum.