### PR TITLE
Securing device identifiers

### DIFF
--- a/_Nontechnical/identity.md
+++ b/_Nontechnical/identity.md
@@ -21,9 +21,9 @@ Policies and procedures provide the details necessary to implement management an
 
 - Provides capabilities within the IoT device to allow for unique identification of each IoT device.
 - Provides instructions for implementing and using the unique IoT identifiers.
+- Provides information about device identifiers such as whether the identifier is securely stored and protected, or is derived from a network address.
 - Provides training videos showing how to implement unique identifiers for the IoT device.
 
 **Agency:**
 
 - Organizational IoT device policies and procedures establish the unique identification required for each IoT device associated with the system and critical system components within which it is used.
-

--- a/_Technical/protection.md
+++ b/_Technical/protection.md
@@ -31,7 +31,7 @@ Ability for the IoT device to use cryptography for data protection. Elements tha
 Ability for the IoT device, or tools used through the IoT device interface, to enable secure device storage. Elements that may be necessary:
 
 - Ability to support encryption of data at rest.
-  - Ability to cryptographically store passwords at rest, as well as other authentication data.
+  - Ability to cryptographically store passwords at rest, as well as device identity and other authentication data.
   - Ability to support data encryption and signing to prevent data from being altered in device storage.
 - Ability to secure data in device storage.
   - Ability to secure data stored locally on the device.
@@ -49,4 +49,3 @@ Ability to secure data transmissions sent to and from the IoT device. Elements t
   - Ability to support data encryption and signing to prevent data from being altered in transit.
 - Ability to utilize one or more capabilities to protect the data it transmits from unauthorized access and modification.
 - Ability to use cryptographic means to validate the integrity of data transmitted.
-


### PR DESCRIPTION
The federal profile currently requires user identity (passwords at rest, authentication data) to be securely stored. This could be extended to include a secure device identity. Network protocol addresses such as a MAC address and an IP address (as described in SP800-53 control IA-3) are useful identifiers of the IoT device but they are insecure and easily spoofed. As such, using network protocol addresses as identifiers is a low security option for use when a low assurance level is dictated by the use case. A secure device identity should be used when a high assurance level is dictated by the use case. For example, a cryptographically protected identity.

In some cases, IoT devices are not user centric, and the secured device identity can be used for authentication. For example, devices that are part of a building’s infrastructure that aren’t associated with a particular user.