### PR TITLE
Add Data Minimization sub-section to Data Protection

### DIFF
--- a/_Technical/protection.md
+++ b/_Technical/protection.md
@@ -50,3 +50,12 @@ Ability to secure data transmissions sent to and from the IoT device. Elements t
 - Ability to utilize one or more capabilities to protect the data it transmits from unauthorized access and modification.
 - Ability to use cryptographic means to validate the integrity of data transmitted.
 
+## Data Minimization
+
+Ability for the IoT device to limit data collection and retention to what is necessary for its intended function. Elements that may be necessary:
+
+- Ability to configure the types of data collected by the device.
+- Ability to disable data collection functions that are not required for the device's primary operational purpose.
+- Ability to limit the retention period of data stored on the device.
+- Ability to automatically purge data after a configurable retention period.
+- Ability to restrict the device from collecting data beyond its defined operational purpose.

--- a/_Technical/security.md
+++ b/_Technical/security.md
@@ -20,6 +20,9 @@ Ability to protect the execution of code on the device. Elements that may be nec
   - Ability to separate IoT device processes into separate execution domains.
 - Ability to separate the levels of IoT device user functionality.
 - Ability to authorize various levels of IoT device functionality.
+- Ability to securely boot the device and verify the integrity of its operating environment before execution.
+- Ability to validate firmware and software integrity at boot time using cryptographic verification (e.g., signed boot images).
+
 
 ## Secure Communication 
 


### PR DESCRIPTION
Organization: Independent Researcher
Organization Type: 4 (Self)
Document: Technical capabilities
Reference: Data Protection (new sub-section)

Feedback: NIST SP 800-53 includes data minimization controls (SA-8, PM-25).
For healthcare IoT devices handling PHI, HIPAA's minimum necessary standard
requires limiting data collection and retention. The current catalog covers
encryption and secure storage but has no data minimization capabilities.
Adding this sub-section aligns the catalog with existing federal privacy
and security control requirements.

Suggested Change: Add a new Data Minimization sub-section with five
elements covering configurable data collection, retention limits, and
automatic purging.
