### PR TITLE
Add vulnerability disclosure policies and procedures

### DIFF
--- a/_Nontechnical/security.md
+++ b/_Nontechnical/security.md
@@ -142,3 +142,20 @@ Policies and procedures provide the details necessary to implement management an
 - Ensure proper language is within IoT device manufacturer contracts, and their external service providers, describing how they will monitor compliance, perform audits, etc., as appropriate to the IoT device and control.
 - Provide a clear description of the legal compliance requirements to the IoT device manufacturer detailing the compliance needs that must be fulfilled by the IoT device manufacturer to meet all associated compliance requirements, as appropriate to the IoT device and controls.
 - Follow procedures to consistently ensure appropriate security and privacy controls language is included within contracts with IoT device manufacturers and service providers.
+
+## Policies and procedures for IoT device vulnerability disclosure.
+
+Policies and procedures provide the details necessary to implement management and operational controls for coordinated vulnerability disclosure for IoT devices. Actions that may be necessary:
+
+**Manufacturer:**
+
+- Establish and maintain a public vulnerability disclosure policy for IoT devices.
+- Provide a mechanism for security researchers and IoT device customers to report vulnerabilities.
+- Provide timely communication to IoT device customers about confirmed vulnerabilities and available mitigations or patches.
+- Maintain a record of reported vulnerabilities, their status, and the timeline for remediation.
+
+**Agency:**
+
+- Implement policies and procedures requiring IoT device manufacturers to maintain a vulnerability disclosure program as a condition of procurement.
+- Implement procedures to monitor manufacturer vulnerability disclosures and apply mitigations within organizationally-defined timeframes.
+- Implement procedures to report newly discovered IoT device vulnerabilities to the manufacturer and to relevant federal vulnerability coordination entities (e.g., CISA).

--- a/_Technical/security.md
+++ b/_Technical/security.md
@@ -20,6 +20,9 @@ Ability to protect the execution of code on the device. Elements that may be nec
   - Ability to separate IoT device processes into separate execution domains.
 - Ability to separate the levels of IoT device user functionality.
 - Ability to authorize various levels of IoT device functionality.
+- Ability to securely boot the device and verify the integrity of its operating environment before execution.
+- Ability to validate firmware and software integrity at boot time using cryptographic verification (e.g., signed boot images).
+
 
 ## Secure Communication 
 


### PR DESCRIPTION
Organization: Independent Researcher
Organization Type: 4 (Self)
Document: Nontechnical capabilities
Reference: Device Security (new section)

Feedback: Coordinated vulnerability disclosure is a foundational expectation
in federal cybersecurity per OMB M-20-32 and Executive Order 14028. FDA also
requires postmarket vulnerability management for connected medical devices.
The current non-technical catalog does not address vulnerability disclosure
as a manufacturer or agency capability.

Suggested Change: Add a new section for vulnerability disclosure policies
and procedures with manufacturer and agency actions.
